### PR TITLE
add support to read request data from json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,7 @@ If you have a JSON file that represents the body of your request, you can use th
 
 Strest will read the JSON file you have specified and add it to the body of the request, you won't even need to worry about the Content-Type header, Strest will take care of that for you.
 
-```
-yaml
+```yaml
 version: 2
 
 requests:

--- a/README.md
+++ b/README.md
@@ -378,6 +378,25 @@ requests:
         expect: "<$ '2019-10-10' | date('YYYY') $>"
 ```
 
+## Sending JSON requests from external files
+
+If you have a JSON file that represents the body of your request, you can use the `json` option.
+
+Strest will read the JSON file you have specified and add it to the body of the request, you won't even need to worry about the Content-Type header, Strest will take care of that for you.
+
+```
+yaml
+version: 2
+
+requests:
+  jsonfile:
+    request:
+      url: https://postman-echo.com/post
+      method: POST
+      json: tests/success/jsonfile/data.json  # You have to put the whole path relative to the current directory that you run strest
+    log: true
+```
+
 ## Sending files and form data
 Sending files and form data is easy, use params type in the postData prop.
 ```yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strest/cli",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "A new dimension of REST API testing",
   "main": "dist/main.js",
   "repository": "https://github.com/eykrehbein/strest",

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -58,6 +58,7 @@ const requestSchema = Joi.object().keys({
   headers: Joi.array().items(headerSchema).optional(),
   queryString: Joi.array().items(queryStringSchema).optional(),
   cookies: Joi.array().items(cookieSchema).optional(),
+  json: Joi.string().optional(),
 })
 
 const validateSchema = Joi.object().keys({
@@ -121,6 +122,7 @@ interface requestObjectSchema {
   headers: Array<headerObjectSchema>,
   queryString: Array<queryStringObjectSchema>,
   cookies: cookiesObjectSchema,
+  json?: string,
 }
 
 interface queryStringObjectSchema {

--- a/src/test.ts
+++ b/src/test.ts
@@ -438,6 +438,13 @@ const performRequest = async (requestObject: requestsObjectSchema, requestName: 
     }
   }
 
+  if (typeof requestObject.request.json !== 'undefined') {
+    axiosObject.headers["Content-Type"] = 'application/json'
+    const file = requestObject.request.json;
+    const json = jsonfile.readFileSync(file);
+    axiosObject.data = json;
+  }
+
   try {
     let axiosInstance = axios.create({
       validateStatus: function (status) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -438,7 +438,7 @@ const performRequest = async (requestObject: requestsObjectSchema, requestName: 
     }
   }
 
-  if (typeof requestObject.request.json !== 'undefined') {
+  if (requestObject.request.json !== undefined) {
     axiosObject.headers["Content-Type"] = 'application/json'
     const file = requestObject.request.json;
     const json = jsonfile.readFileSync(file);

--- a/tests/success/Value/moment.strest.yml
+++ b/tests/success/Value/moment.strest.yml
@@ -10,7 +10,7 @@ requests:
           value: <$ now | date('YYYY') $>
       validate:
       - jsonpath: content.args.foo
-        expect: "<$ '2019-10-10' | date('YYYY') $>"
+        expect: "<$ '2020-10-10' | date('YYYY') $>"
     moment-in-validate:
       request:
         url: https://postman-echo.com/time/format?timestamp=2019-10-10&format=YYYY

--- a/tests/success/jsonfile/data.json
+++ b/tests/success/jsonfile/data.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/tests/success/jsonfile/jsonfile.strest.yml
+++ b/tests/success/jsonfile/jsonfile.strest.yml
@@ -1,0 +1,8 @@
+version: 2
+
+requests:
+  jsonfile:
+    request:
+      url: https://postman-echo.com/post
+      method: POST
+      json: tests/success/jsonfile/data.json  # You have to put the whole path relative to the current directory that you run strest


### PR DESCRIPTION
# What does this Pull Request do?

It adds support to read from JSON files to fill the request body.

## Use case

Sometimes, the request body is just massive and adding it to the request using the text attribute is out of option. Having the ability to read from a JSON file makes it a lot easier to control the strest test file.

## Other

This fixes an issue with the moment tests that was failing as well because of the new year.